### PR TITLE
Added github action that counts percentage of comment lines and writes it as an artifact

### DIFF
--- a/.github/workflows/comments-to-lines-ratio.yml
+++ b/.github/workflows/comments-to-lines-ratio.yml
@@ -3,7 +3,7 @@ on: [push]
 
 jobs:
   cloc:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Check-out repo.
         uses: actions/checkout@v4


### PR DESCRIPTION
The github action uses [cloc](https://github.com/AlDanial/cloc) to count the lines of code, the empty lines, and the comment lines, and makes a rundown of all of these per file and per language.
The summary is saved to a markdown file and uploaded as an artifact.
Relevant ticket: [link](https://www.notion.so/CI-CD-workflow-for-comment-analysis-182e2f39f5624cd397090ad0bd93368c)