### PR TITLE
Fixed get_base_image_name() function

### DIFF
--- a/xrf_explorer/server/file_system/file_access.py
+++ b/xrf_explorer/server/file_system/file_access.py
@@ -263,7 +263,11 @@ def get_base_image_path(data_source_folder_name: str) -> str | None:
         LOG.error("Config is empty")
         return None
 
-    filename: str | None = get_base_image_name(data_source_folder_name)
+    workspace_dict: dict = get_workspace_dict(data_source_folder_name)
+    if workspace_dict is None:
+        return None
+
+    filename: str | None = workspace_dict["baseImage"]["imageLocation"]
 
     if filename is not None:
         return join(backend_config["uploads-folder"], data_source_folder_name, filename)


### PR DESCRIPTION
Before it returned `imageLocation` but it should actually return the `name` since `get_contextual_image_data()` was changed.
Also had to change the `get_base_image_path()` function accordingly.