### PR TITLE
Fix by simply initializing `ready` earlier in the function

### DIFF
--- a/xrf_explorer/client/src/windows/SpectraWindow.vue
+++ b/xrf_explorer/client/src/windows/SpectraWindow.vue
@@ -17,6 +17,7 @@ import { flipSelectionAreaSelection } from "@/lib/utils";
 import { getTargetSize } from "@/components/image-viewer/api";
 
 const spectraChart = ref<HTMLElement>();
+let ready: boolean = false;
 // SVG container
 let svg = d3.select(spectraChart.value!);
 let x = d3.scaleLinear();
@@ -33,7 +34,6 @@ watch(spectraChart, (value) => (exportableElements["Spectral"] = value), { immed
 
 const config = inject<FrontendConfig>("config")!;
 const url = config.api.endpoint;
-let ready: boolean = false;
 
 // set the dimensions and margins of the graph
 const margin = { top: 30, right: 30, bottom: 70, left: 60 },


### PR DESCRIPTION
Fixes #121 

`ready` variable was at some point being accessed before being initialized, which would print an error to the console whenever you opened the webapp.
Moving the variable initialization/declaration a bit earlier in the file fixed it (in particular I'm pretty sure that it just has to be before the `watch(areaSelection, getSelectionSpectrum, { deep: true, immediate: true });` line).