### PR TITLE
Renamed "data source" to "project" in frontend

### DIFF
--- a/xrf_explorer/client/src/components/menus/FileMenu.vue
+++ b/xrf_explorer/client/src/components/menus/FileMenu.vue
@@ -52,9 +52,9 @@ function loadWorkspace(source: string) {
     <MenubarMenu>
       <MenubarTrigger @click="() => request.execute()"> File </MenubarTrigger>
       <MenubarContent>
-        <DialogTrigger class="w-full"><MenubarItem>New data source</MenubarItem></DialogTrigger>
+        <DialogTrigger class="w-full"><MenubarItem>New project</MenubarItem></DialogTrigger>
         <MenubarSeparator />
-        <MenubarItem disabled v-if="sources.length <= 0">No data sources available</MenubarItem>
+        <MenubarItem disabled v-if="sources.length <= 0">No projects available</MenubarItem>
         <MenubarItem v-for="source in sources" :key="source" @click="() => loadWorkspace(source)">
           {{ source }}
         </MenubarItem>

--- a/xrf_explorer/client/src/components/workspace/CreateWorkspaceDialog.vue
+++ b/xrf_explorer/client/src/components/workspace/CreateWorkspaceDialog.vue
@@ -55,7 +55,7 @@ enum Progress {
 
 const progress = ref(Progress.Name);
 
-// Data source name
+// Project name
 const sourceName = ref("");
 
 // Dialogs for file and channel setup
@@ -64,7 +64,7 @@ const fileDialog = ref(false);
 const channelDialog = ref(false);
 
 /**
- * Creates the data source directory in the backend if it does not yet exist with a workspace.json inside.
+ * Creates the project/data source directory in the backend if it does not yet exist with a workspace.json inside.
  */
 async function initializeDataSource() {
   if (progress.value == Progress.Name) {
@@ -77,7 +77,7 @@ async function initializeDataSource() {
       toast.warning("Project name must not be empty");
       return;
     }
-    // Create the data source directory
+    // Create the project directory
     const response = await fetch(`${config.api.endpoint}/${name}/create`, { method: "POST" });
 
     // Check if the request was successful
@@ -131,7 +131,7 @@ function deletedExistingFiles() {
 }
 
 /**
- * Resets the progress for creating a new data source.
+ * Resets the progress for creating a new project/data source.
  */
 function resetProgress() {
   progress.value = Progress.Busy;
@@ -151,10 +151,10 @@ async function abortDataSourceCreation() {
 
     if (response.ok) {
       const data = await response.json();
-      console.info(`Data source directory removed: ${data.dataSourceDir}`);
+      console.info(`Project directory removed: ${data.dataSourceDir}`);
     } else {
       const error = await response.text();
-      console.error(`Error removing data source directory: ${error}`);
+      console.error(`Error removing project directory: ${error}`);
     }
   } catch (error) {
     console.error(`An error occurred: ${error}`);
@@ -287,8 +287,8 @@ async function binData() {
 
 <template>
   <DialogContent ref="dialog">
-    <DialogTitle class="mb-2 font-bold"> Create new data source </DialogTitle>
-    <Input placeholder="Data source name" :disabled="progress != Progress.Name" v-model:model-value="sourceName" />
+    <DialogTitle class="mb-2 font-bold"> Create new project </DialogTitle>
+    <Input placeholder="Project name" :disabled="progress != Progress.Name" v-model:model-value="sourceName" />
     <div class="flex items-center justify-between">
       <div class="flex items-center space-x-1.5" v-if="progress == Progress.Name">
         <TriangleAlert class="size-5 text-primary" />

--- a/xrf_explorer/client/src/components/workspace/ExistingFilesDialog.vue
+++ b/xrf_explorer/client/src/components/workspace/ExistingFilesDialog.vue
@@ -8,7 +8,7 @@ const config = inject<FrontendConfig>("config")!;
 
 const props = defineProps<{
   /**
-   * The name of the relevant data source.
+   * The name of the relevant project.
    */
   name: string;
 }>();
@@ -22,7 +22,7 @@ const fileFetch = useFetch<string>(fileUrl, { refetch: true });
 const files = computed<string[]>(() => JSON.parse(fileFetch.data.value ?? "[]"));
 
 /**
- * Deletes all files and recreates the data source directory.
+ * Deletes all files and recreates the project directory.
  */
 async function deleteFiles() {
   await fetch(`${config.api.endpoint}/${name.value}/delete`, { method: "DELETE" });

--- a/xrf_explorer/client/src/components/workspace/FileUploadDialog.vue
+++ b/xrf_explorer/client/src/components/workspace/FileUploadDialog.vue
@@ -14,7 +14,7 @@ const emit = defineEmits(["filesUploaded"]);
 
 const props = defineProps<{
   /**
-   * The name of the data source to upload files to.
+   * The name of the project/data source to upload files to.
    */
   dataSource: string;
 }>();


### PR DESCRIPTION
At some comments where we mentioned data source I just added project/data source because the variable/functions name still say data source and it might be too messy to change that. User should only see "Project" in the UI anyway.