### PR TITLE
Fetch files only once the dialog has been opened

### DIFF
--- a/xrf_explorer/client/src/components/workspace/ExistingFilesDialog.vue
+++ b/xrf_explorer/client/src/components/workspace/ExistingFilesDialog.vue
@@ -20,10 +20,13 @@ const fileUrl = computed(() => `${config.api.endpoint}/${name.value}/files`);
 const fileFetch = useFetch<string>(fileUrl, { immediate: false });
 const files = computed<string[]>(() => JSON.parse(fileFetch.data.value ?? "[]"));
 
-watch(name, (value) => {
-  if (value != "")
-    fileFetch.execute();
-}, { immediate: true, deep: true });
+watch(
+  name,
+  (value) => {
+    if (value != "") fileFetch.execute();
+  },
+  { immediate: true, deep: true },
+);
 
 /**
  * Deletes all files and recreates the project directory.


### PR DESCRIPTION
fixes an error because of a request to `/api//files` when the project doesn't have a name yet