### PR TITLE
Renamed last few instances of lasso in backend to polygon

### DIFF
--- a/documentation/sphinx/source/dim_reduction.rst
+++ b/documentation/sphinx/source/dim_reduction.rst
@@ -23,9 +23,9 @@ Loading the overlay can take a couple of seconds, depending on the size of the e
 
 Use the selection tool 
 ---------------------------
-When showing an embedding image, the user can use the lasso tool to see the relation between the painting and the embedding.
-For this, select the lasso tool or the rectangle tool from the toolbar in the dimensionality reduction window.
-By clicking (in the case of the lasso tool), or clicking and dragging (in the case of the rectangle tool), the user can select a region in the embedding.
+When showing an embedding image, the user can use the polygon tool to see the relation between the painting and the embedding.
+For this, select the polygon tool or the rectangle tool from the toolbar in the dimensionality reduction window.
+By clicking (in the case of the polygon tool), or clicking and dragging (in the case of the rectangle tool), the user can select a region in the embedding.
 The indices corresponding to the selected region are then shown in the painting.
 
 
@@ -41,9 +41,9 @@ To combat this, the server will down sample the data at random to the maximum al
 This maximum is set to make sure that the generation time of the embedding is not too long.
 When the indices are down sampled, a pop-up message will appear indication that this has happened.
 
-For the lasso tool, the non-down sampled indices are used.
+For the polygon tool, the non-down sampled indices are used.
 The values in the embedding corresponding to the indices that were not in the down sampled set are determined by nearest neighbor interpolation.
-This is done to make the highlighting of the lasso tool more visible.
+This is done to make the highlighting of the polygon tool more visible.
 
 
 Interpretation of the embedding

--- a/tests/test_image_to_cube_selection.py
+++ b/tests/test_image_to_cube_selection.py
@@ -152,20 +152,20 @@ class TestImageToCubeSelection:
         bottom_right: tuple[int, int] = (345, 678)
 
         coords_rect: list[tuple[int, int]] = [top_left, bottom_right]
-        coords_lasso: list[tuple[int, int]] = [top_left, top_right, bottom_right, bottom_left]
+        coords_polygon: list[tuple[int, int]] = [top_left, top_right, bottom_right, bottom_left]
 
         # execute
         selection_data_rect: np.ndarray | None = get_selection(
             self.DATA_SOURCE_FOLDER_NAME, coords_rect, SelectionType.Rectangle, CubeType.Elemental
         )
-        selection_data_lasso: np.ndarray | None = get_selection(
-            self.DATA_SOURCE_FOLDER_NAME, coords_lasso, SelectionType.Polygon, CubeType.Elemental
+        selection_data_polygon: np.ndarray | None = get_selection(
+            self.DATA_SOURCE_FOLDER_NAME, coords_polygon, SelectionType.Polygon, CubeType.Elemental
         )
 
         # verify
         assert selection_data_rect is not None
-        assert selection_data_lasso is not None
-        assert np.array_equal(selection_data_rect, selection_data_lasso)
+        assert selection_data_polygon is not None
+        assert np.array_equal(selection_data_rect, selection_data_polygon)
 
     def test_negative_coordinates(self):
         # setup
@@ -180,32 +180,32 @@ class TestImageToCubeSelection:
         bottom_left_outside: tuple[int, int] = (0, img_h + 10)
 
         coords_rect: list[tuple[int, int]] = [top_left, bottom_right]
-        coords_lasso: list[tuple[int, int]] = [top_left, top_right, bottom_right, bottom_left]
+        coords_polygon: list[tuple[int, int]] = [top_left, top_right, bottom_right, bottom_left]
         coords_rect_outside: list[tuple[int, int]] = [top_left_outside, bottom_right]
-        coords_lasso_outside: list[tuple[int, int]] = [top_left_outside, top_right, bottom_right, bottom_left_outside]
+        coords_polygon_outside: list[tuple[int, int]] = [top_left_outside, top_right, bottom_right, bottom_left_outside]
 
         # execute
         selection_data_rect: np.ndarray | None = get_selection(
             self.DATA_SOURCE_FOLDER_NAME, coords_rect, SelectionType.Rectangle, CubeType.Elemental
         )
-        selection_data_lasso: np.ndarray | None = get_selection(
-            self.DATA_SOURCE_FOLDER_NAME, coords_lasso, SelectionType.Polygon, CubeType.Elemental
+        selection_data_polygon: np.ndarray | None = get_selection(
+            self.DATA_SOURCE_FOLDER_NAME, coords_polygon, SelectionType.Polygon, CubeType.Elemental
         )
         selection_data_rect_outside: np.ndarray | None = get_selection(
             self.DATA_SOURCE_FOLDER_NAME, coords_rect_outside, SelectionType.Rectangle, CubeType.Elemental
         )
-        selection_data_lasso_outside: np.ndarray | None = get_selection(
-            self.DATA_SOURCE_FOLDER_NAME, coords_lasso_outside, SelectionType.Polygon, CubeType.Elemental
+        selection_data_polygon_outside: np.ndarray | None = get_selection(
+            self.DATA_SOURCE_FOLDER_NAME, coords_polygon_outside, SelectionType.Polygon, CubeType.Elemental
         )
 
         # verify
         assert selection_data_rect is not None
-        assert selection_data_lasso is not None
+        assert selection_data_polygon is not None
         assert selection_data_rect_outside is not None
-        assert selection_data_lasso_outside is not None
+        assert selection_data_polygon_outside is not None
 
-        assert np.array_equal(selection_data_rect, selection_data_lasso)
-        assert np.array_equal(selection_data_rect_outside, selection_data_lasso_outside)
+        assert np.array_equal(selection_data_rect, selection_data_polygon)
+        assert np.array_equal(selection_data_rect_outside, selection_data_polygon_outside)
         assert np.array_equal(selection_data_rect_outside, selection_data_rect)
 
     def test_ribbon_selection(self):
@@ -218,7 +218,7 @@ class TestImageToCubeSelection:
         bottom_right: tuple[int, int] = (img_w - 1, img_h - 1)
 
         coords_rect: list[tuple[int, int]] = [top_left, bottom_right]
-        coords_lasso: list[tuple[int, int]] = [top_left, bottom_right, top_right, bottom_left]
+        coords_polygon: list[tuple[int, int]] = [top_left, bottom_right, top_right, bottom_left]
 
         tolerance_percentage: float = 0.01  # 1% tolerance
 
@@ -226,17 +226,17 @@ class TestImageToCubeSelection:
         selection_data_rect: np.ndarray | None = get_selection(
             self.DATA_SOURCE_FOLDER_NAME, coords_rect, SelectionType.Rectangle, CubeType.Elemental
         )
-        selection_data_lasso: np.ndarray | None = get_selection(
-            self.DATA_SOURCE_FOLDER_NAME, coords_lasso, SelectionType.Polygon, CubeType.Elemental
+        selection_data_polygon: np.ndarray | None = get_selection(
+            self.DATA_SOURCE_FOLDER_NAME, coords_polygon, SelectionType.Polygon, CubeType.Elemental
         )
         tolerance: float = np.count_nonzero(selection_data_rect) * tolerance_percentage
 
         # verify
         assert selection_data_rect is not None
-        assert selection_data_lasso is not None
+        assert selection_data_polygon is not None
 
         # ribbon selection must be about half of the rect selection
-        assert abs(np.count_nonzero(selection_data_rect) - np.count_nonzero(selection_data_lasso) * 2) <= tolerance
+        assert abs(np.count_nonzero(selection_data_rect) - np.count_nonzero(selection_data_polygon) * 2) <= tolerance
 
     # Return true if cube_coord_expected is within tolerance_pixels from the cube coordinate calculated by
     # deregister_coord.

--- a/xrf_explorer/server/dim_reduction/general.py
+++ b/xrf_explorer/server/dim_reduction/general.py
@@ -66,7 +66,7 @@ def get_path_to_dr_folder(data_source: str) -> str:
 
 
 def create_image_of_indices_to_embedding(data_source: str) -> bool:
-    """Creates the image for lasso selection that decodes to which points in the embedding the pixels of the elemental
+    """Creates the image for polygon selection that decodes to which points in the embedding the pixels of the elemental
     data cube are mapped. Uses the current embedding and indices to create the image.
 
     :param data_source: Name of the data source

--- a/xrf_explorer/server/image_to_cube_selection/image_to_cube_selection.py
+++ b/xrf_explorer/server/image_to_cube_selection/image_to_cube_selection.py
@@ -204,7 +204,9 @@ def get_selection(
 
     :param data_source_folder: The data source folder name.
     :param selection_coords: The coordinates tuples (x, y), in order, of the selection. In case of a rectangle 
-    :param selection_type: The type of selection being performed. selection, the list must contain the two opposite corners of the selection rectangle. In case of lasso selection, the list must contain the points in the order in which they form the selection area.
+    :param selection_type: The type of selection being performed. selection, the list must contain the two opposite
+    corners of the selection rectangle. In case of polygon selection, the list must contain the points in the order in
+    which they form the selection area.
     :param cube_type: The type of the cube the selection is made on.
     :return: A boolean mask over the data cube indicating which pixels are part of the selection.
     """
@@ -213,7 +215,7 @@ def get_selection(
         return None
 
     if selection_type == SelectionType.Polygon and len(selection_coords) < 3:
-        LOG.error(f"Expected at least 3 points for lasso selection but got {len(selection_coords)}")
+        LOG.error(f"Expected at least 3 points for polygon selection but got {len(selection_coords)}")
         return None
 
     base_img_dir: str | None = get_base_image_path(data_source_folder)

--- a/xrf_explorer/server/routes.py
+++ b/xrf_explorer/server/routes.py
@@ -495,7 +495,7 @@ def get_dr_overlay(data_source: str, overlay_type: str):
 
 @app.route("/api/<data_source>/dr/embedding/mapping")
 def get_dr_embedding_mapping(data_source: str):
-    """Creates the image for lasso selection that decodes to which points in the embedding the pixels of the elemental
+    """Creates the image for polygon selection that decodes to which points in the embedding the pixels of the elemental
     data cube are mapped. Uses the current embedding and indices for the given data source to create the image.
 
     :param data_source: data source to get the overlay from


### PR DESCRIPTION
Now, "Lasso" only appears for the icon import `LassoSelect` we make in `Toolbar.vue` and `DRWindow.vue`.

Fixes #109